### PR TITLE
fix build for boost 1.85

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -58,9 +58,14 @@
 #include	"LinearFrameDisplay.h"
 #include	"CubicFrameDisplay.h"
 
+#include	<boost/version.hpp>
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
+#if BOOST_VERSION < 108500
 #include	"boost/filesystem/convenience.hpp"
+#else // BOOST_VERSION >= 1.85
+#include	"boost/filesystem/directory.hpp"
+#endif
 
 #if defined(MAC) || defined(WIN32)
 	#define HONOR_VBL_SYNC
@@ -69,7 +74,9 @@
 using boost::filesystem::path;
 using boost::filesystem::exists;
 using boost::filesystem::directory_iterator;
+#if BOOST_VERSION < 108500
 using boost::filesystem::extension;
+#endif
 
 using namespace DisplayOutput;
 

--- a/client_generic/Client/lua_playlist.h
+++ b/client_generic/Client/lua_playlist.h
@@ -15,15 +15,21 @@
 #include "isaac.h"
 #include "ContentDownloader.h"
 
+#include	<boost/version.hpp>
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
+#if BOOST_VERSION < 108500
 #include	"boost/filesystem/convenience.hpp"
-#include	<boost/thread.hpp>
+#else // BOOST_VERSION >= 1.85
+#include	"boost/filesystem/directory.hpp"
+#endif
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
 using boost::filesystem::directory_iterator;
+#if BOOST_VERSION < 108500
 using boost::filesystem::extension;
+#endif
 
 
 //	Lua.

--- a/client_generic/ContentDecoder/graph_playlist.h
+++ b/client_generic/ContentDecoder/graph_playlist.h
@@ -11,15 +11,22 @@
 #include <sstream>
 
 
+#include	<boost/version.hpp>
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
+#if BOOST_VERSION < 108500
 #include	"boost/filesystem/convenience.hpp"
+#else // BOOST_VERSION >= 1.85
+#include	"boost/filesystem/directory.hpp"
+#endif
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
 using boost::filesystem::no_check;
 using boost::filesystem::directory_iterator;
+#if BOOST_VERSION < 108500
 using boost::filesystem::extension;
+#endif
 
 namespace ContentDecoder
 {

--- a/client_generic/TupleStorage/luastorage.cpp
+++ b/client_generic/TupleStorage/luastorage.cpp
@@ -7,14 +7,24 @@
 #include	"luastorage.h"
 #include	"clientversion.h"
 
+#include	<boost/version.hpp>
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
+#if BOOST_VERSION < 108500
 #include	"boost/filesystem/convenience.hpp"
+#else // BOOST_VERSION >= 1.85
+#include	"boost/filesystem/directory.hpp"
+#endif
+#include	"boost/filesystem/path.hpp"
+#include	"boost/filesystem/operations.hpp"
+#include	"boost/filesystem/directory.hpp"
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
 using boost::filesystem::directory_iterator;
+#if BOOST_VERSION < 108500
 using boost::filesystem::extension;
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
boost 1.85 removed the convenience.hpp header. 
Also boost::filesystem::extension does not exist anymore. 

In order not to break builds with older boost, I included the corresponding header file conditionally an the boost version. Conveniently this is available in /usr/include/boost/version.hpp

I built this against boost 1.85 and 1.84 to make sure it is working.