### PR TITLE
Remove use of deprecated `<boost/filesystem/convenience.hpp>`

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -60,7 +60,6 @@
 
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
-#include	"boost/filesystem/convenience.hpp"
 
 #if defined(MAC) || defined(WIN32)
 	#define HONOR_VBL_SYNC
@@ -68,8 +67,6 @@
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
-using boost::filesystem::directory_iterator;
-using boost::filesystem::extension;
 
 using namespace DisplayOutput;
 

--- a/client_generic/Client/lua_playlist.h
+++ b/client_generic/Client/lua_playlist.h
@@ -17,13 +17,10 @@
 
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
-#include	"boost/filesystem/convenience.hpp"
 #include	<boost/thread.hpp>
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
-using boost::filesystem::directory_iterator;
-using boost::filesystem::extension;
 
 
 //	Lua.

--- a/client_generic/ContentDecoder/graph_playlist.h
+++ b/client_generic/ContentDecoder/graph_playlist.h
@@ -13,13 +13,11 @@
 
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
-#include	"boost/filesystem/convenience.hpp"
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
 using boost::filesystem::no_check;
 using boost::filesystem::directory_iterator;
-using boost::filesystem::extension;
 
 namespace ContentDecoder
 {
@@ -116,7 +114,7 @@ class	CGraphPlaylist : public CPlaylist
 		for( directory_iterator i( _dir ), end; i != end; ++i )
 		{
 			#warning TODO (Keffo#1#): Remove hardcoded extension...
-			if( extension(*i) != ".avi" )
+			if( i->extension().string() != ".avi" )
 				continue;
 
 			std::string file = i->string();

--- a/client_generic/TupleStorage/luastorage.cpp
+++ b/client_generic/TupleStorage/luastorage.cpp
@@ -9,12 +9,9 @@
 
 #include	"boost/filesystem/path.hpp"
 #include	"boost/filesystem/operations.hpp"
-#include	"boost/filesystem/convenience.hpp"
 
 using boost::filesystem::path;
 using boost::filesystem::exists;
-using boost::filesystem::directory_iterator;
-using boost::filesystem::extension;
 
 using namespace std;
 


### PR DESCRIPTION
This header was dropped in Boost 1.85.