### PR TITLE
Fix modern linux build

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -12,7 +12,7 @@
 #ifndef LINUX_GNU
 #include	"GLee.h"
 #else
-#include <GLee.h>
+#include <GL/glew.h>
 #include <endian.h>
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __LITTLE_ENDIAN__ __LITTLE_ENDIAN
@@ -231,7 +231,16 @@ bool CPlayer::AddDisplay( uint32 screen )
 		return false;
 #endif
 	
- 	spRenderer = new CRendererGL();
+
+	// Initialize GLEW now that we have a GL context
+	GLenum err = glewInit();
+	if (GLEW_OK != err)
+	{
+		g_Log->Error("GLEW Init failed: %s", (const char*)glewGetErrorString(err));
+		return false;
+	}
+
+	spRenderer = new CRendererGL();
 #endif
 
 	//	Start renderer & set window title.
@@ -643,9 +652,10 @@ bool	CPlayer::Update(uint32 displayUnit, bool &bPlayNoSheepIntro)
 		du = m_displayUnits[ displayUnit ];
 	}
 
-	du->spRenderer->Reset( eEverything );
-	du->spRenderer->Orthographic();
-	du->spRenderer->Apply();
+	// No longer needed, as we're using GLEW to initialize the GL context
+	//du->spRenderer->Reset( eEverything );
+	//du->spRenderer->Orthographic();
+	//du->spRenderer->Apply();
 	
 	{
 		boost::mutex::scoped_lock lockthis( m_updateMutex );

--- a/client_generic/DisplayOutput/OpenGL/RendererGL.cpp
+++ b/client_generic/DisplayOutput/OpenGL/RendererGL.cpp
@@ -3,7 +3,7 @@
 #ifndef LINUX_GNU
 #include	"./OpenGL/GLee.h"
 #else
-#include <GLee.h>
+#include <GL/glew.h>
 #endif
 #ifdef MAC
 #include	<OpenGL/CGLMacro.h>

--- a/client_generic/DisplayOutput/OpenGL/ShaderGL.cpp
+++ b/client_generic/DisplayOutput/OpenGL/ShaderGL.cpp
@@ -6,7 +6,7 @@
 #include	"./OpenGL/GLee.h"
 #include <OpenGL/CGLMacro.h>
 #else
-#include<GLee.h>
+#include <GL/glew.h>
 #endif
 
 #include	"Exception.h"
@@ -97,7 +97,7 @@ bool	CShaderGL::Build( const char *_pVertexShader, const char *_pFragmentShader 
 	GLint len, infoLogPos = 0;
 
 	//	Compile to the highest supported language version.
-	if( GLEE_ARB_shading_language_100 )
+	if( GLEW_ARB_shading_language_100 )
 	{
 		static char versionString[ 16 ];
 		static bool bFirst = true;
@@ -369,8 +369,8 @@ bool	CShaderUniformGL::SetData( void *_pData, const uint32 _size )
 	return true;
 }
 
-typedef GLvoid (APIENTRY *Uniform_Func)(GLint location, GLsizei count, const void *value);
-typedef GLvoid (APIENTRY *Uniform_MatrixFunc)(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+typedef GLvoid (*Uniform_Func)(GLint location, GLsizei count, const void *value);
+typedef GLvoid (*Uniform_MatrixFunc)(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
 
 /*
 */

--- a/client_generic/DisplayOutput/OpenGL/TextureFlatGL.cpp
+++ b/client_generic/DisplayOutput/OpenGL/TextureFlatGL.cpp
@@ -4,7 +4,7 @@
 #ifndef LINUX_GNU
 #include "GLee.h"
 #else
-#include <GLee.h>
+#include <GL/glew.h>
 #endif
 #ifdef MAC
 #include <OpenGL/CGLMacro.h>
@@ -210,9 +210,9 @@ bool	CTextureFlatGL::Upload( spCImage _spImage )
 #endif
 			
 #ifndef LINUX_GNU
-			if( GLEE_ARB_texture_non_power_of_two || m_TexTarget == GL_TEXTURE_RECTANGLE_EXT )
+			if( GLEW_ARB_texture_non_power_of_two || m_TexTarget == GL_TEXTURE_RECTANGLE_EXT )
 #else
-			if( GLEE_ARB_texture_non_power_of_two || m_TexTarget == GL_TEXTURE_RECTANGLE_ARB )
+			if( GLEW_ARB_texture_non_power_of_two || m_TexTarget == GL_TEXTURE_RECTANGLE_ARB )
 
 #endif
 			{

--- a/client_generic/DisplayOutput/OpenGL/glx.cpp
+++ b/client_generic/DisplayOutput/OpenGL/glx.cpp
@@ -464,14 +464,22 @@ void CUnixGL::alwaysOnTop()
 */
 void CUnixGL::toggleVSync()
 {
-    m_VSync = !m_VSync;
-
-    if( GLEE_GLX_SGI_swap_control )
+    // Check if the swap control extension is available
+    const char *extensions = glXQueryExtensionsString(m_pDisplay, DefaultScreen(m_pDisplay));
+    if (strstr(extensions, "GLX_EXT_swap_control") != NULL)
     {
-        if( m_VSync )
-            glXSwapIntervalSGI(1);
-        else
-            glXSwapIntervalSGI(2);
+        // Get the function pointer for glXSwapIntervalEXT
+        PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT =
+            (PFNGLXSWAPINTERVALEXTPROC)glXGetProcAddressARB((const GLubyte*)"glXSwapIntervalEXT");
+
+        if (glXSwapIntervalEXT)
+        {
+            int interval = 0;
+            if (m_VSync == 1) interval = 1;
+            else if (m_VSync == 2) interval = 2;
+
+            glXSwapIntervalEXT(m_pDisplay, m_GlxWindow, interval);
+        }
     }
 }
 

--- a/client_generic/DisplayOutput/OpenGL/glx.h
+++ b/client_generic/DisplayOutput/OpenGL/glx.h
@@ -13,7 +13,8 @@
 #ifndef LINUX_GNU
 #include "GLee.h"
 #else
-#include <GLee.h>
+#include <GL/glew.h>
+#include <GL/glx.h>
 #endif
 #include "DisplayOutput.h"
 

--- a/client_generic/MSVC/SettingsGUI/electricsheepguiMyDialog2.cpp
+++ b/client_generic/MSVC/SettingsGUI/electricsheepguiMyDialog2.cpp
@@ -418,7 +418,7 @@ void electricsheepguiMyDialog2::Login()
     FireLoginStatusUpdateEvent("...talking...");
 	wxMutexGuiLeave();
 
-	m_Role == "error";
+	m_Role = "error";
 	long code = 0;
 	m_Response.clear();
 	if (code = curl_easy_perform(pCurl) == CURLE_OK)

--- a/client_generic/configure.ac
+++ b/client_generic/configure.ac
@@ -169,31 +169,8 @@ AC_SUBST(LUA_LIBS)
 
 dnl Check for glee
 
-PKG_CHECK_MODULES([GLEE],[glee], [HAVE_GLEE=true] , [HAVE_GLEE=false] )
-if test "$HAVE_GLEE" = "false"; then
-
-   PKG_CHECK_MODULES([GLEE],[GLee], [HAVE_GLEE=true] , [HAVE_GLEE=false] )
-   if test "$HAVE_GLEE" = "false"; then
-      AC_MSG_CHECKING(for GLee.h)
-      AC_CHECK_HEADERS(GLee.h GL/GLee.h)
-
-      if test "x$ac_cv_header_GLee_h" = "xno"; then
-      	 if test "x$ac_cv_header_GL_GLee_h" = "xno"; then
-      	    AC_MSG_ERROR([neither GLee.h nor GL/GLee.h were found. Please make sure you have GLee.h installed in your include path.])
-      	 fi
-      	 dnl found GLee.h in GL subdir
-      	 GLEE_CFLAGS="-I $includedir/GL -I/usr/include/GL"
-      fi
-
-      AC_CHECK_LIB([GLee],[main],GLEE_LIBS="-lGLee",
-	AC_CHECK_LIB([glee],[main],GLEE_LIBS="-lglee",,))
-
-      fi
-
-fi
-AC_SUBST(GLEE_CFLAGS)
-AC_SUBST(GLEE_LIBS)
-
+PKG_CHECK_MODULES([GLEE], [glew],,
+  [AC_MSG_ERROR([GLEW not found. Please make sure libglew-dev is installed.])])
 
 dnl Check for curl
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,8 @@
 -Introduction
 -How to Use
 -Flame Algorithm 
+-Building and Installing from Source
+-Running from the Command Line
 -Copyright and License
 -Creator and Founder of Electric Sheep
 
@@ -33,13 +35,11 @@ For those using Debian/Ubuntu, you'll first need to install all dependencies:
 sudo apt-get install make automake build-essential subversion autoconf libtool libgtk2.0-dev libgl1-mesa-dev libavcodec-dev libavformat-dev libswscale-dev liblua5.1-0-dev libcurl4-openssl-dev libxml2-dev libjpeg8-dev libgtop2-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev freeglut3-dev libglew-dev libwxgtk3.2-dev
 ```
 
-Next, clone the repo, then build and install:
+Next, clone the repo, then build and install.  Note that the configure command expects older versions of aclocal and automake and so we'll work around this by making symlinks.
 
 ```
 git clone https://github.com/scottdraves/flam3.git
 cd flam3
-# ./configure expects older versions of aclocal and automake so these symbolic links
-# are a workaround for that dependendy
 sudo ln -s $(which aclocal) /usr/local/bin/aclocal-1.15
 sudo ln -s $(which automake) /usr/local/bin/automake-1.15
 ./configure
@@ -59,7 +59,7 @@ make
 sudo make install
 ```
 
-# Running from the Command linked
+# Running from the Command Line
 
 Once built, the main executable is:
 ```

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,51 @@ After you have installed and ran the main source code, you can get comfortable w
 # Flame Algorithm 
 You can also visit the following website: https://flam3.com/. This website is separate from the main Electric Sheep website and talks about the flame algorithm that you are installing from the source code more in the depth. 
 
+# Building and Installing from Source
+
+## Flame
+
+It's recommended to first build and install flam3 before you build and install the Electric Sheep client.
+
+For those using Debian/Ubuntu, you'll first need to install all dependencies:
+
+```
+sudo apt-get install make automake build-essential subversion autoconf libtool libgtk2.0-dev libgl1-mesa-dev libavcodec-dev libavformat-dev libswscale-dev liblua5.1-0-dev libcurl4-openssl-dev libxml2-dev libjpeg8-dev libgtop2-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev freeglut3-dev libglew-dev libwxgtk3.2-dev
+```
+
+Next, clone the repo, then build and install:
+
+```
+git clone https://github.com/scottdraves/flam3.git
+cd flam3
+./configure
+make
+sudo make install
+```
+
+## Electric Sheep
+
+```
+git clone https://github.com/scottdraves/electricsheep.git
+cd electricsheep/client_generic
+./autogen.sh
+./configure
+make
+sudo make install
+```
+
+# Running from the Command linked
+
+The main executable is:
+```
+electricsheep
+```
+
+You can configure settings by running:
+```
+electricsheep-preferences
+```
+
 # Copyright and License
 Copyright Spotworks LLC
 GPL2 Licensed see https://github.com/scottdraves/electricsheep/blob/master/client_generic/COPYING

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,12 @@ Next, clone the repo, then build and install:
 ```
 git clone https://github.com/scottdraves/flam3.git
 cd flam3
+# ./configure expects older versions of aclocal and automake so these symbolic links
+# are a workaround for that dependendy
+sudo ln -s $(which aclocal) /usr/local/bin/aclocal-1.15
+sudo ln -s $(which automake) /usr/local/bin/automake-1.15
 ./configure
+automake --add-missing --copy
 make
 sudo make install
 ```
@@ -56,12 +61,12 @@ sudo make install
 
 # Running from the Command linked
 
-The main executable is:
+Once built, the main executable is:
 ```
 electricsheep
 ```
 
-You can configure settings by running:
+You can also configure settings by running this (which is built with the main executable):
 ```
 electricsheep-preferences
 ```


### PR DESCRIPTION
In modern Linux, GLEE has been replaced by GLEW.  In addition to updating the source to reflect this change, it's essential to install the correct dependencies prior to building flam3 and electricsheep/client_generic.  The correct dependencies for modern Debian/Ubuntu are:

sudo apt-get install make automake build-essential subversion autoconf libtool libgtk2.0-dev libgl1-mesa-dev libavcodec-dev libavformat-dev libswscale-dev liblua5.1-0-dev libcurl4-openssl-dev libxml2-dev libjpeg8-dev libgtop2-dev libboost-dev libboost-filesystem-dev libboost-thread-dev libtinyxml-dev freeglut3-dev libglew-dev libwxgtk3.2-dev

This PR has been tested on Ubuntu 24.04.3 LTS x64 with X11 and GNOME 46.